### PR TITLE
Add support for Xrootd replicas

### DIFF
--- a/base/qserv.yaml
+++ b/base/qserv.yaml
@@ -15,3 +15,5 @@ spec:
       dbimage: "mariadb:10.2.16"
   xrootd:
     image: "qserv/qserv:dcbfff7"
+    replicas: 3
+

--- a/configmap/xrootd/etc/xrootd.cf
+++ b/configmap/xrootd/etc/xrootd.cf
@@ -71,9 +71,12 @@ xrd.network dyndns
 xrd.network cache 0
 
 # TODO Generate xrootd redirector list using go template
+set xrootreps = {{.XrootdReplicas}}
 set xrootddn = {{.XrootdRedirectorDn}}
-all.manager ${xrootddn}-0.${xrootddn}:2131
-all.manager ${xrootddn}-1.${xrootddn}:2131
+for i := 1;  i<=xrootreps; i++ {
+    all.manager ${xrootddn}-0.${xrootddn}:2131
+    all.manager ${xrootddn}-1.${xrootddn}:2131
+}
 
 # - cmsd redirector runs on port 2131
 # - cmsd server does not open server socket

--- a/deploy/crds/qserv_v1alpha1_qserv_cr.yaml
+++ b/deploy/crds/qserv_v1alpha1_qserv_cr.yaml
@@ -14,3 +14,4 @@ spec:
   xrootd:
     replicas: 3
     image: "qserv/qserv:9701693"
+    replicas: 3

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: qserv-operator
           # Replace this with the built image name
-          image: qserv/qserv-operator:f54bb5c-dirty
+          image: gcr.io/poised-standard-268114/qserv/qserv-operator:updated-replicas-pushed
           command:
           - qserv-operator
           imagePullPolicy: Always

--- a/pkg/scheme/qserv/configmap.go
+++ b/pkg/scheme/qserv/configmap.go
@@ -80,7 +80,8 @@ func GenerateContainerConfigMap(r *qservv1alpha1.Qserv, labels map[string]string
 	tmplData := templateData{
 		CzarDomainName:             util.GetCzarServiceName(r),
 		QstatusMysqldHost:  util.GetCzarServiceName(r),
-		XrootdRedirectorDn: util.GetXrootdRedirectorServiceName(r)}
+		XrootdRedirectorDn: util.GetXrootdRedirectorServiceName(r)
+		XrootdReplicas: util.GetXrootdReplicas(r)}
 
 	reqLogger := log.WithValues("Request.Namespace", r.Namespace, "Request.Name", r.Name)
 

--- a/pkg/scheme/qserv/statefulset.go
+++ b/pkg/scheme/qserv/statefulset.go
@@ -299,8 +299,8 @@ func GenerateXrootdStatefulSet(cr *qservv1alpha1.Qserv, labels map[string]string
 
 	labels = util.MergeLabels(labels, util.GetLabels(constants.XrootdRedirectorName, cr.Name))
 
-	var replicas int32 = 2
-
+	var replicas int32 = cr.Spec.Xrootd.Replicas
+	
 	containers, volumes := getXrootdContainers(cr, constants.XrootdRedirectorName)
 
 	ss := &appsv1.StatefulSet{

--- a/pkg/util/name.go
+++ b/pkg/util/name.go
@@ -88,3 +88,8 @@ func GetSecretName(cr *qservv1alpha1.Qserv, containerName constants.ContainerNam
 func GetSecretVolumeName(containerName constants.ContainerName) string {
 	return fmt.Sprintf("secret-%s", containerName)
 }
+
+// GetXrootdReplicas returns num of Xrootd replicas defined in cr.Spec.Xrootd.Replicas
+func GetXrootdReplicas(cr *qservv1alpha1.Qserv) string {
+	return (cr, cr.Spec.Xrootd.Replicas)
+}


### PR DESCRIPTION
This PR is intended to complete the task 2 given under qualification task for the GSoC project "Kubernetes operator for XRootD".
In ```deploy/operator.yaml ``` the image ```gcr.io/poised-standard-268114/qserv/qserv-operator:updated-replicas-pushed``` as it is a custom built which is being hosted in the Google Container Registry (At the moment image pull secret is not required as the deployment and the container registry are in the same GKE project)

@fjammes Please review this PR 