### PR TITLE
[DM-24733] Added support of network policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ script:
   - kind load docker-image "$OP_IMAGE"
   - ./deploy/qserv.sh --dev --install-kubedb
   - kubectl apply -k overlays/ci-redis
-  - ./wait-qserv-ready.sh
+  - kubectl get networkpolicies
   - kubectl get all,endpoints,cm,pvc,pv -o wide
+  - ./wait-qserv-ready.sh -v
   - ./run-integration-tests.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,24 @@ language: go
 dist: xenial
 
 go:
-- 1.13.4
+  - 1.13.4
 
 before_script:
   - if [ "$DOCKER_USERNAME" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi
   - ./install-operator-sdk.sh
-  - git clone --depth 1 -b "v0.6.0" --single-branch https://github.com/k8s-school/kind-travis-ci.git
-  - ./kind-travis-ci/kind/k8s-create.sh -s
+  - git clone --depth 1 -b "master" --single-branch https://github.com/shivanshs9/kind-travis-ci.git
+  - ./kind-travis-ci/kind/k8s-create.sh -sc
 
 script:
   - . ./env.sh
   - ./build.sh
   - kind load docker-image "$OP_IMAGE"
-  - ./deploy/qserv.sh --dev --install-kubedb 
-  - kubectl apply -k overlays/ci-redis 
-  - ./wait-qserv-ready.sh 
+  - ./deploy/qserv.sh --dev --install-kubedb
+  - kubectl apply -k overlays/ci-redis
+  - ./wait-qserv-ready.sh
   - kubectl get all,endpoints,cm,pvc,pv -o wide
   - ./run-integration-tests.sh
 
 after_success:
   - echo "Generate and upload documentation"
-  - curl -fsSL https://raw.githubusercontent.com/lsst/doc-container/tickets\/DM-23256/run.sh | bash -s -- -p "$LTD_PASSWORD" "$PWD" 
+  - curl -fsSL https://raw.githubusercontent.com/lsst/doc-container/tickets\/DM-23256/run.sh | bash -s -- -p "$LTD_PASSWORD" "$PWD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 before_script:
   - if [ "$DOCKER_USERNAME" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi
   - ./install-operator-sdk.sh
-  - git clone --depth 1 -b "master" --single-branch https://github.com/k8s-school/kind-travis-ci.git
+  - git clone --depth 1 -b "k8s-v1.18.2" --single-branch https://github.com/k8s-school/kind-travis-ci.git
   - ./kind-travis-ci/k8s-create.sh -sc
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,17 @@ go:
 before_script:
   - if [ "$DOCKER_USERNAME" ]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi
   - ./install-operator-sdk.sh
-  - git clone --depth 1 -b "master" --single-branch https://github.com/shivanshs9/kind-travis-ci.git
-  - ./kind-travis-ci/kind/k8s-create.sh -sc
+  - git clone --depth 1 -b "master" --single-branch https://github.com/k8s-school/kind-travis-ci.git
+  - ./kind-travis-ci/k8s-create.sh -sc
 
 script:
   - . ./env.sh
   - ./build.sh
   - kind load docker-image "$OP_IMAGE"
   - ./deploy/qserv.sh --dev --install-kubedb
-  - kubectl apply -k overlays/ci-redis
-  - kubectl get networkpolicies
-  - kubectl get all,endpoints,cm,pvc,pv -o wide
-  - ./wait-qserv-ready.sh -v
+  - kubectl apply -k base
+  - ./wait-qserv-ready.sh
+  - kubectl get all,endpoints,cm,pvc,pv,networkpolicies -o wide
   - ./run-integration-tests.sh
 
 after_success:

--- a/base/qserv.yaml
+++ b/base/qserv.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   storageclass: "standard"
   storagecapacity: "1Gi"
+  securenetwork: true
   czar:
     image: "qserv/qserv:dcbfff7"
   worker:

--- a/base/qserv.yaml
+++ b/base/qserv.yaml
@@ -5,15 +5,15 @@ metadata:
 spec:
   storageclass: "standard"
   storagecapacity: "1Gi"
-  securenetwork: true
+  networkpolicies: true
   czar:
     image: "qserv/qserv:dcbfff7"
   worker:
     replicas: 2
     image: "qserv/qserv:dcbfff7"
   replication:
-      image: "qserv/replica:tools-w.2018.16-1171-gcbabd53"
-      dbimage: "mariadb:10.2.16"
+    image: "qserv/replica:tools-w.2018.16-1171-gcbabd53"
+    dbimage: "mariadb:10.2.16"
   xrootd:
     image: "qserv/qserv:dcbfff7"
     replicas: 2

--- a/deploy/crds/qserv.lsst.org_qservs_crd.yaml
+++ b/deploy/crds/qserv.lsst.org_qservs_crd.yaml
@@ -60,6 +60,11 @@ spec:
                 image:
                   type: string
               type: object
+            securenetwork:
+              default: false
+              description: SecureNetwork secures the cluster network using Network
+                Policies. Ensure the Kubernetes cluster has enabled Network plugin.
+              type: boolean
             storagecapacity:
               type: string
             storageclass:

--- a/deploy/crds/qserv.lsst.org_qservs_crd.yaml
+++ b/deploy/crds/qserv.lsst.org_qservs_crd.yaml
@@ -40,6 +40,11 @@ spec:
                   format: int32
                   type: integer
               type: object
+            networkpolicies:
+              default: false
+              description: NetworkPolicies secures the cluster network using Network
+                Policies. Ensure the Kubernetes cluster has enabled Network plugin.
+              type: boolean
             redis:
               description: Redis defines the settings for redis cluster
               properties:
@@ -60,11 +65,6 @@ spec:
                 image:
                   type: string
               type: object
-            securenetwork:
-              default: false
-              description: SecureNetwork secures the cluster network using Network
-                Policies. Ensure the Kubernetes cluster has enabled Network plugin.
-              type: boolean
             storagecapacity:
               type: string
             storageclass:

--- a/deploy/operator.yaml.tpl
+++ b/deploy/operator.yaml.tpl
@@ -19,7 +19,7 @@ spec:
           image: REPLACE_IMAGE
           command:
           - qserv-operator
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/qserv.sh
+++ b/deploy/qserv.sh
@@ -125,7 +125,11 @@ if [ "$KUBEDB" = true ]; then
   )
 fi
 
-kubectl wait --for=condition=Ready pods -l name=qserv-operator -n "$NAMESPACE"
+while ! kubectl wait --for=condition=Ready pods -l name=qserv-operator -n "$NAMESPACE"
+do
+  echo "Waiting for operator to be ready..."
+  kubectl describe pod -l name=qserv-operator -n "$NAMESPACE"
+done
 
 echo
 echo "Successfully installed Qserv operator in '$NAMESPACE' namespace."

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -14,6 +14,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - networkpolicies
   verbs:
   - create
   - delete
@@ -22,6 +23,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+    - networkpolicies
+  verbs:
+    - '*'
 - apiGroups:
   - apps
   resources:

--- a/overlays/ci-redis/qserv.yaml
+++ b/overlays/ci-redis/qserv.yaml
@@ -3,10 +3,10 @@ kind: Qserv
 metadata:
   name: qserv
 spec:
+  securenetwork: true
   worker:
     replicas: 2
   redis:
     version: "5.0.3"
     master: 3
     replicas: 1
-

--- a/overlays/ci-redis/qserv.yaml
+++ b/overlays/ci-redis/qserv.yaml
@@ -3,7 +3,7 @@ kind: Qserv
 metadata:
   name: qserv
 spec:
-  securenetwork: true
+  networkpolicies: true
   worker:
     replicas: 2
   redis:

--- a/pkg/apis/qserv/v1alpha1/qserv_types.go
+++ b/pkg/apis/qserv/v1alpha1/qserv_types.go
@@ -40,6 +40,11 @@ type QservSpec struct {
 
 	// Xrootd defines the settings for worker cluster
 	Xrootd XrootdSettings `json:"xrootd,omitempty"`
+
+	// SecureNetwork secures the cluster network using Network Policies.
+	// Ensure the Kubernetes cluster has enabled Network plugin.
+	// +kubebuilder:default:=false
+	SecureNetwork bool `json:"securenetwork,omitempty"`
 }
 
 // CzarSettings defines the specification of the czar cluster

--- a/pkg/apis/qserv/v1alpha1/qserv_types.go
+++ b/pkg/apis/qserv/v1alpha1/qserv_types.go
@@ -41,10 +41,10 @@ type QservSpec struct {
 	// Xrootd defines the settings for worker cluster
 	Xrootd XrootdSettings `json:"xrootd,omitempty"`
 
-	// SecureNetwork secures the cluster network using Network Policies.
+	// NetworkPolicies secures the cluster network using Network Policies.
 	// Ensure the Kubernetes cluster has enabled Network plugin.
 	// +kubebuilder:default:=false
-	SecureNetwork bool `json:"securenetwork,omitempty"`
+	NetworkPolicies bool `json:"networkpolicies,omitempty"`
 }
 
 // CzarSettings defines the specification of the czar cluster

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,6 +53,7 @@ const (
 	ReplName             ComponentName = "repl"
 	WorkerName           ComponentName = "worker"
 	XrootdRedirectorName ComponentName = "xrootd-redirector"
+	NetworkPolicy        ComponentName = "network-policy"
 )
 
 // ContainerConfigmaps contains names of all micro-services which require configmaps named:

--- a/pkg/controller/qserv/internal/sync/network.go
+++ b/pkg/controller/qserv/internal/sync/network.go
@@ -2,15 +2,20 @@ package sync
 
 import (
 	qservv1alpha1 "github.com/lsst/qserv-operator/pkg/apis/qserv/v1alpha1"
+	"github.com/lsst/qserv-operator/pkg/constants"
 	"github.com/lsst/qserv-operator/pkg/scheme/qserv"
 	"github.com/lsst/qserv-operator/pkg/staging/syncer"
+	"github.com/lsst/qserv-operator/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func NewNetworkPoliciesSyncer(r *qservv1alpha1.Qserv, c client.Client, scheme *runtime.Scheme) []syncer.Interface {
-	policy := qserv.GenerateDefaultNetworkPolicy(r, controllerLabels)
+	labels := util.MergeLabels(controllerLabels, util.GetLabels(constants.NetworkPolicy, r.Name))
 	return []syncer.Interface{
-		syncer.NewObjectSyncer("DefaultNetworkPolicy", r, policy, c, scheme, noFunc),
+		syncer.NewObjectSyncer("DefaultNetworkPolicy", r, qserv.GenerateDefaultNetworkPolicy(r, labels), c, scheme, noFunc),
+		syncer.NewObjectSyncer("CzarNetworkPolicy", r, qserv.GenerateCzarNetworkPolicy(r, labels), c, scheme, noFunc),
+		syncer.NewObjectSyncer("ReplDBNetworkPolicy", r, qserv.GenerateReplDBNetworkPolicy(r, labels), c, scheme, noFunc),
+		syncer.NewObjectSyncer("WorkerNetworkPolicy", r, qserv.GenerateWorkerNetworkPolicy(r, labels), c, scheme, noFunc),
 	}
 }

--- a/pkg/controller/qserv/internal/sync/network.go
+++ b/pkg/controller/qserv/internal/sync/network.go
@@ -1,0 +1,16 @@
+package sync
+
+import (
+	qservv1alpha1 "github.com/lsst/qserv-operator/pkg/apis/qserv/v1alpha1"
+	"github.com/lsst/qserv-operator/pkg/scheme/qserv"
+	"github.com/lsst/qserv-operator/pkg/staging/syncer"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewNetworkPoliciesSyncer(r *qservv1alpha1.Qserv, c client.Client, scheme *runtime.Scheme) []syncer.Interface {
+	policy := qserv.GenerateDefaultNetworkPolicy(r, controllerLabels)
+	return []syncer.Interface{
+		syncer.NewObjectSyncer("DefaultNetworkPolicy", r, policy, c, scheme, noFunc),
+	}
+}

--- a/pkg/controller/qserv/internal/sync/network.go
+++ b/pkg/controller/qserv/internal/sync/network.go
@@ -17,5 +17,6 @@ func NewNetworkPoliciesSyncer(r *qservv1alpha1.Qserv, c client.Client, scheme *r
 		syncer.NewObjectSyncer("CzarNetworkPolicy", r, qserv.GenerateCzarNetworkPolicy(r, labels), c, scheme, noFunc),
 		syncer.NewObjectSyncer("ReplDBNetworkPolicy", r, qserv.GenerateReplDBNetworkPolicy(r, labels), c, scheme, noFunc),
 		syncer.NewObjectSyncer("WorkerNetworkPolicy", r, qserv.GenerateWorkerNetworkPolicy(r, labels), c, scheme, noFunc),
+		syncer.NewObjectSyncer("XrootdRedirectoryNetworkPolicy", r, qserv.GenerateXrootdRedirectorNetworkPolicy(r, labels), c, scheme, noFunc),
 	}
 }

--- a/pkg/controller/qserv/qserv_controller.go
+++ b/pkg/controller/qserv/qserv_controller.go
@@ -135,7 +135,9 @@ func (r *ReconcileQserv) Reconcile(request reconcile.Request) (reconcile.Result,
 	}
 
 	// Specify Network Policies
-	syncers = append(syncers, sync.NewNetworkPoliciesSyncer(qserv, r.client, r.scheme)...)
+	if qserv.Spec.SecureNetwork {
+		syncers = append(syncers, sync.NewNetworkPoliciesSyncer(qserv, r.client, r.scheme)...)
+	}
 
 	if err = r.sync(syncers); err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/qserv/qserv_controller.go
+++ b/pkg/controller/qserv/qserv_controller.go
@@ -134,6 +134,9 @@ func (r *ReconcileQserv) Reconcile(request reconcile.Request) (reconcile.Result,
 		syncers = append(syncers, sync.NewSqlConfigMapSyncer(qserv, r.client, r.scheme, db))
 	}
 
+	// Specify Network Policies
+	syncers = append(syncers, sync.NewNetworkPoliciesSyncer(qserv, r.client, r.scheme)...)
+
 	if err = r.sync(syncers); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/qserv/qserv_controller.go
+++ b/pkg/controller/qserv/qserv_controller.go
@@ -135,7 +135,7 @@ func (r *ReconcileQserv) Reconcile(request reconcile.Request) (reconcile.Result,
 	}
 
 	// Specify Network Policies
-	if qserv.Spec.SecureNetwork {
+	if qserv.Spec.NetworkPolicies {
 		syncers = append(syncers, sync.NewNetworkPoliciesSyncer(qserv, r.client, r.scheme)...)
 	}
 

--- a/pkg/scheme/qserv/network.go
+++ b/pkg/scheme/qserv/network.go
@@ -185,7 +185,7 @@ func GenerateXrootdRedirectorNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[s
 			},
 			Ingress: []v1.NetworkPolicyIngressRule{
 				{
-					// DB port
+					// CMSD port
 					Ports: []v1.NetworkPolicyPort{
 						{
 							Port: &intstr.IntOrString{
@@ -198,6 +198,24 @@ func GenerateXrootdRedirectorNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[s
 							// Only Xrootd workers can access the redirector CMSD
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: util.GetLabels(constants.WorkerName, cr.Name),
+							},
+						},
+					},
+				},
+				{
+					// Xrootd port
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								IntVal: constants.XrootdPort,
+							},
+						},
+					},
+					From: []v1.NetworkPolicyPeer{
+						{
+							// Only CZAR can access the redirector Xrootd port
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: util.GetLabels(constants.CzarName, cr.Name),
 							},
 						},
 					},

--- a/pkg/scheme/qserv/network.go
+++ b/pkg/scheme/qserv/network.go
@@ -45,7 +45,7 @@ func GenerateCzarNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string
 					Ports: []v1.NetworkPolicyPort{
 						{
 							Port: &intstr.IntOrString{
-								IntVal: 3306,
+								IntVal: constants.MariadbPort,
 							},
 						},
 					},
@@ -63,7 +63,7 @@ func GenerateCzarNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string
 					Ports: []v1.NetworkPolicyPort{
 						{
 							Port: &intstr.IntOrString{
-								IntVal: 4040,
+								IntVal: constants.ProxyPort,
 							},
 						},
 					},
@@ -93,7 +93,7 @@ func GenerateReplDBNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]stri
 					Ports: []v1.NetworkPolicyPort{
 						{
 							Port: &intstr.IntOrString{
-								IntVal: 3306,
+								IntVal: constants.MariadbPort,
 							},
 						},
 					},
@@ -131,7 +131,7 @@ func GenerateWorkerNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]stri
 					Ports: []v1.NetworkPolicyPort{
 						{
 							Port: &intstr.IntOrString{
-								IntVal: 3306,
+								IntVal: constants.MariadbPort,
 							},
 						},
 					},
@@ -149,7 +149,7 @@ func GenerateWorkerNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]stri
 					Ports: []v1.NetworkPolicyPort{
 						{
 							Port: &intstr.IntOrString{
-								IntVal: 1094,
+								IntVal: constants.XrootdPort,
 							},
 						},
 					},
@@ -159,7 +159,45 @@ func GenerateWorkerNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]stri
 					Ports: []v1.NetworkPolicyPort{
 						{
 							Port: &intstr.IntOrString{
-								IntVal: 5012,
+								IntVal: constants.WmgrPort,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func GenerateXrootdRedirectorNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
+	return &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-xrootd-redirector-ingress",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{
+				v1.PolicyTypeIngress,
+			},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: util.GetLabels(constants.XrootdRedirectorName, cr.Name),
+			},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				{
+					// DB port
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								IntVal: constants.CmsdPort,
+							},
+						},
+					},
+					From: []v1.NetworkPolicyPeer{
+						{
+							// Only Xrootd workers can access the redirector CMSD
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: util.GetLabels(constants.WorkerName, cr.Name),
 							},
 						},
 					},

--- a/pkg/scheme/qserv/network.go
+++ b/pkg/scheme/qserv/network.go
@@ -6,16 +6,14 @@ import (
 	"github.com/lsst/qserv-operator/pkg/util"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func GenerateDefaultNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
-	namespace := cr.Namespace
-	labels = util.MergeLabels(labels, util.GetLabels(constants.NetworkPolicy, cr.Name))
-
 	return &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default-deny-ingress",
-			Namespace: namespace,
+			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
 		Spec: v1.NetworkPolicySpec{
@@ -23,6 +21,150 @@ func GenerateDefaultNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]str
 				v1.PolicyTypeIngress,
 			},
 			PodSelector: metav1.LabelSelector{},
+		},
+	}
+}
+
+func GenerateCzarNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
+	return &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-czar-ingress",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{
+				v1.PolicyTypeIngress,
+			},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: util.GetLabels(constants.CzarName, cr.Name),
+			},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				{
+					// DB port
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								IntVal: 3306,
+							},
+						},
+					},
+					From: []v1.NetworkPolicyPeer{
+						{
+							// Only Replication Controller can access the DB
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: util.GetLabels(constants.ReplName, cr.Name),
+							},
+						},
+					},
+				},
+				{
+					// Proxy port
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								IntVal: 4040,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func GenerateReplDBNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
+	return &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-repl-db-ingress",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{
+				v1.PolicyTypeIngress,
+			},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: util.GetLabels(constants.ReplName, cr.Name),
+			},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				{
+					// DB port
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								IntVal: 3306,
+							},
+						},
+					},
+					From: []v1.NetworkPolicyPeer{
+						// {
+						// 	// Only Replication Controller can access the DB
+						// 	PodSelector: &metav1.LabelSelector{
+						// 		MatchLabels: util.GetLabels(constants.ReplName, cr.Name),
+						// 	},
+						// },
+					},
+				},
+			},
+		},
+	}
+}
+
+func GenerateWorkerNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
+	return &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-worker-ingress",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{
+				v1.PolicyTypeIngress,
+			},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: util.GetLabels(constants.WorkerName, cr.Name),
+			},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				{
+					// DB port
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								IntVal: 3306,
+							},
+						},
+					},
+					From: []v1.NetworkPolicyPeer{
+						// {
+						// 	// Only Replication Controller can access the DB
+						// 	PodSelector: &metav1.LabelSelector{
+						// 		MatchLabels: util.GetLabels(constants.ReplName, cr.Name),
+						// 	},
+						// },
+					},
+				},
+				{
+					// Xrootd port
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								IntVal: 1094,
+							},
+						},
+					},
+				},
+				{
+					// Wmgr port
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								IntVal: 5012,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/scheme/qserv/network.go
+++ b/pkg/scheme/qserv/network.go
@@ -1,0 +1,28 @@
+package qserv
+
+import (
+	qservv1alpha1 "github.com/lsst/qserv-operator/pkg/apis/qserv/v1alpha1"
+	"github.com/lsst/qserv-operator/pkg/constants"
+	"github.com/lsst/qserv-operator/pkg/util"
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GenerateDefaultNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
+	namespace := cr.Namespace
+	labels = util.MergeLabels(labels, util.GetLabels(constants.NetworkPolicy, cr.Name))
+
+	return &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-deny-ingress",
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{
+				v1.PolicyTypeIngress,
+			},
+			PodSelector: metav1.LabelSelector{},
+		},
+	}
+}

--- a/wait-qserv-ready.sh
+++ b/wait-qserv-ready.sh
@@ -26,7 +26,17 @@
 
 set -eux
 
+VERBOSE=false
 DIR=$(cd "$(dirname "$0")"; pwd -P)
+
+while test $# -gt 0; do
+  case "$1" in
+    -v | --verbose)
+      VERBOSE=true
+      shift
+      ;;
+  esac
+done
 
 INSTANCE=$(kubectl get qservs.qserv.lsst.org -o=jsonpath='{.items[0].metadata.name}')
 WORKER_COUNT=$(kubectl get qservs.qserv.lsst.org "$INSTANCE" -o=jsonpath='{.spec.worker.replicas}')
@@ -40,6 +50,9 @@ while ! kubectl wait pod --for=condition=Ready --timeout="10s" -l "app=qserv,ins
 do
   echo "Wait for Qserv pods to be ready:"
   kubectl get pod -l "app=qserv,instance=$INSTANCE"
+  if [ "$VERBOSE" = true ]; then
+    kubectl describe pod -l "app=qserv,instance=$INSTANCE"
+  fi
 done
 
 echo "Qserv pods are ready:"


### PR DESCRIPTION
### Network Policies
- [x] Added default-deny policy
- [x] All connections to Qserv czar proxy should then be opened
- [x] Replication controller should be able to connect to czar database
- [x] Replication worker should be able to connect to replication database
- [ ] Connection between replication controller and replication worker should be clarified
- [ ] Connection between xrootd components should be clarified
   - [x] Redirector CMSD port <- Workers

### Integration Tests:
- [x] Passing
    - Failing since all ingress traffic is blocked.
