### PR TITLE
Upgrade to operator-skd 1.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Operator Logs**
+```
+<Paste the logs here>
+<Run `kubectl logs -l name=xrootd-operator` to get the logs>
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+# Qserv operator CI workflow
+---
+name: "CI"
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    name: Build qserv-operator
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Declare Version Variables
+        id: vars
+        shell: bash
+        run: |
+          echo "::set-env name=OP_IMAGE::$(. ./env.sh && echo $OP_IMAGE)"
+      - name: Setup Operator SDK
+        uses: k8s-school/setup-k8s-operator-sdk@v1
+        with:
+          version: "^1.0.0"
+      - name: Run Unit Tests
+        run: make test
+      - name: Build operator image
+        run: |
+          git checkout "$PWD"
+          ./build.sh
+      - name: Scan operator image
+        uses: anchore/scan-action@v2
+        with:
+          image: "${{ env.OP_IMAGE }}"
+          acs-report-enable: true
+      - name: upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif
+  # WARN: Github action runner are too weak to run Qserv e2e tests
+  # e2e:
+  #   name: Run e2e tests on qserv-operator
+  #   runs-on: ubuntu-18.04
+  #   needs: build
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
+  #     - name: Create k3s Cluster
+  #       uses: debianmaster/actions-k3s@master
+  #       id: k3s
+  #       with:
+  #         version: 'v0.9.1'
+  #     - run: |
+  #         kubectl get nodes
+  #         kubectl get storageclasses.storage.k8s.io
+  #         kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+  #         kubectl get storageclasses.storage.k8s.io
+  #     - name: Setup kustomize
+  #       uses: imranismail/setup-kustomize@v1
+  #       with:
+  #         kustomize-version: "3.1.0"
+  #     - name: Deploy operator
+  #       run: ./deploy.sh
+  #     - name: Apply a sample manifest
+  #       run: kubectl apply -k manifests/k3s
+  #     - name: Wait for Qserv to start
+  #       run: ./tests/tools/wait-qserv-ready.sh -v
+  #     - name: Run E2E Tests
+  #       run: ./tests/e2e/integration.sh

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,18 @@
+# Qserv operator CI workflow
+---
+name: "Documentation"
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+jobs:
+  doc:
+    name: Generate and upload documentation
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Generate and upload documentation
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/lsst-dm/doc-container/master/run.sh | bash -s -- -p "${{ secrets.LTD_PASSWORD }}"  -u "${{ secrets.LTD_USERNAME }}" "$PWD"

--- a/.github/workflows/go-report.yml
+++ b/.github/workflows/go-report.yml
@@ -1,0 +1,15 @@
+# Report card workflow
+---
+name: Generate code reports
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  report:
+    name: Update code report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Go report card
+        uses: creekorful/goreportcard-action@v1.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,80 @@
+# Static Checks Workflow
+---
+name: "Static code analysis"
+on: 
+  pull_request:
+  push:
+
+jobs:
+  imports:
+    name: Imports
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: check
+        uses: grandcolline/golang-github-actions@v1.1.0
+        with:
+          run: imports
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  errcheck:
+    name: Errcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: check
+        uses: grandcolline/golang-github-actions@v1.1.0
+        with:
+          run: errcheck
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: check
+        uses: grandcolline/golang-github-actions@v1.1.0
+        with:
+          run: lint
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  shadow:
+    name: Shadow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: check
+        uses: grandcolline/golang-github-actions@v1.1.0
+        with:
+          run: shadow
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  staticcheck:
+    name: StaticCheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: check
+        uses: grandcolline/golang-github-actions@v1.1.0
+        with:
+          run: staticcheck
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  sec:
+    name: Sec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: check
+        uses: grandcolline/golang-github-actions@v1.1.0
+        with:
+          run: sec
+          token: ${{ secrets.GITHUB_TOKEN }}
+          flags: "-exclude=G104"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,3 @@ script:
   - ./tests/tools/wait-qserv-ready.sh
   - kubectl get all,endpoints,cm,pvc,pv,networkpolicies -o wide
   - ./tests/e2e/integration.sh 
-
-after_success:
-  - echo "Generate and upload documentation"
-  - curl -fsSL https://raw.githubusercontent.com/lsst-dm/doc-container/master/run.sh | bash -s -- -p "$LTD_PASSWORD" "$PWD"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # Current Operator version
-VERSION ?= 0.0.1
 
 SHELL := /bin/bash
+
+ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+ENVFILE := $(ROOT_DIR)/env.sh
+VERSION := $(shell . $(ENVFILE) ; echo $${VERSION})
 
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
@@ -15,7 +18,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG := $(shell . $(ENVFILE) ; echo $${OP_IMAGE})
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -124,3 +127,8 @@ bundle: manifests
 .PHONY: bundle-build
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+##@ Versioning
+.PHONY: version
+version: ## Shows the current release version based on version/version.go
+	@. $(ENVFILE) ; echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # qserv-operator
 
-A qserv operator for Kubernetes based on [operator-framework](https://github.com/operator-framework). You may be familiar with Operators from the concept’s [introduction in 2016](https://coreos.com/blog/introducing-operators.html). An Operator is a method of packaging, deploying and managing a Kubernetes application.
+A qserv operator for Kubernetes based on [operator-framework](https://github.com/operator-framework). An Operator is a method of packaging, deploying and managing a Kubernetes application.
 
-[![Build Status](https://travis-ci.com/lsst/qserv-operator.svg?branch=master)](https://travis-ci.com/lsst/qserv-operator)
-[![Go Report Card](https://goreportcard.com/badge/github.com/lsst/qserv-operator)](https://goreportcard.com/report/github.com/lsst/qserv-operator)
+## Continuous integration for master branch
+
+Build Qserv-operator and run Qserv multi-node integration tests (using a fixed Qserv version)
+
+| CI       | Status                                                                                                                                                           | Image build  | e2e tests | Documentation generation        | Static code analysis  | Image security scan |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|-----------|---------------------------------|-----------------------|---------------------|
+| Gihub    | [![Qserv CI](https://github.com/lsst/qserv-operator/workflows/CI/badge.svg?branch=master)](https://github.com/lsst/qserv-operator/actions?query=workflow%3A"CI") | Yes          | No        | https://qserv-operator.lsst.io/ | Yes                   | Yes                 |
+| Travis   | [![Build Status](https://travis-ci.org/lsst/qserv-operator.svg?branch=master)](https://travis-ci.org/lsst/qserv-operator)                                        | Yes          | Yes (k8s) | No                              | No                    | No                  |
 
 ## Documentation
 
-Access to [Qserv-operator documentation at https://qserv-operator.lsst.io](https://qserv-operator.lsst.io/)
+Access to [Qserv-operator documentation at https://qserv-operator.lsst.io](https://qserv-operator.lsst.io/
+
+# Code analysis
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/xrootd/xrootd-k8s-operator)](https://goreportcard.com/report/github.com/xrootd/xrootd-k8s-operator)
+
+[Security overview](https://github.com/lsst/qserv-operator/security)

--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
+Test latest qserv image: qserv/qserv:2607ae1
+
 Export metrics:
 https://sdk.operatorframework.io/docs/building-operators/golang/project_migration_guide/#export-metrics
-

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ Usage: `basename $0` [options] path host [host ...]
 
   Available options:
     -h          this message
-    -k          development mode: load image in kind instead of pushing it to docker hub
+    -k          development mode: load image in kind
 
 Build qserv-operator image from source code.
 EOD
@@ -49,6 +49,4 @@ make docker-build IMG="$OP_IMAGE"
 
 if [ $kind = true ]; then
   kind load docker-image "$OP_IMAGE"
-else
-  docker push "$OP_IMAGE" || echo "WARN: unable to push qserv-operator image to Docker hub"
 fi

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: qserv/qserv-operator
-  newTag: bc952ff-dirty
+  newTag: 0.0.1-7ffd846

--- a/controllers/qserv_controller.go
+++ b/controllers/qserv_controller.go
@@ -40,15 +40,6 @@ type QservReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// getPodNames returns the pod names of the array of pods passed in
-func getPodNames(pods []v1.Pod) []string {
-	var podNames []string
-	for _, pod := range pods {
-		podNames = append(podNames, pod.Name)
-	}
-	return podNames
-}
-
 // labelsForQserv returns the labels for selecting the resources
 // belonging to the given qserv CR name.
 func labelsForQserv(name string) map[string]string {
@@ -62,6 +53,7 @@ func labelsForQserv(name string) map[string]string {
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services;services/finalizers;configmaps;secrets,verbs=create;delete;get;list;patch;update;watch
 
+// Reconcile reconciles a Qserv object
 func (r *QservReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	ctx := context.Background()
@@ -111,7 +103,7 @@ func (r *QservReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	qservSyncers = append(qservSyncers, syncers.NewContainerConfigMapSyncer(qserv, r.Client, r.Scheme, constants.InitDbName, "start"))
 
 	for _, db := range constants.Databases {
-		qservSyncers = append(qservSyncers, syncers.NewSqlConfigMapSyncer(qserv, r.Client, r.Scheme, db))
+		qservSyncers = append(qservSyncers, syncers.NewSQLConfigMapSyncer(qserv, r.Client, r.Scheme, db))
 	}
 
 	// Specify Network Policies
@@ -150,6 +142,7 @@ func (r *QservReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager setups Qserv controller for k8s
 func (r *QservReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&qservv1alpha1.Qserv{}).

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,29 +1,12 @@
 #!/bin/bash
 
 # Deploy Qserv operator:
-#   - when used from inside qserv-operator git repository, install local version of qserv-operator
-#   - when used in standalone mode , clone qserv-operator to temporary directory and launch inner deploy.sh
+#   must be used from inside qserv-operator git repository, install local version of qserv-operator
 
 set -euxo pipefail
 
 DIR=$(cd "$(dirname "$0")"; pwd -P)
 
-OPERATOR='qserv-operator'
-GIT_REF='tickets/DM-26295'
-REPO_NAME=''
-if cd $DIR && git rev-parse --is-inside-work-tree 2>/dev/null; then
-  REMOTE_REPO_URL=$(git --git-dir=$DIR/.git remote get-url origin)
-  REPO_NAME=$(basename -s .git $REMOTE_REPO_URL)
-fi
-
-GIT_REF="tickets/DM-26295"
-if [ "$REPO_NAME" != "$OPERATOR" ]; then
-  TMP_DIR=$(mktemp -d --suffix "$OPERATOR")/qserv-operator
-  git clone --depth 1 -b "$GIT_REF" --single-branch https://github.com/lsst/"$OPERATOR".git "$TMP_DIR"
-  "$TMP_DIR"/deploy.sh
-else
-  . "$DIR/env.sh"
-  make install
-  make deploy IMG="$OP_IMAGE"
-  $DIR/tests/tools/wait-operator-ready.sh
-fi
+. "$DIR/env.sh"
+make deploy
+$DIR/tests/tools/wait-operator-ready.sh

--- a/doc/install/quick-start.rst
+++ b/doc/install/quick-start.rst
@@ -52,13 +52,18 @@ Option #2: k3s
     curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC=“--docker --write-kubeconfig-mode 644” sh -
     export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
-Install Qserv in two lines
-==========================
+Install Qserv in four lines
+===========================
+
+`go-lang` is a pre-requisite.
 
 .. code:: bash
 
-    curl -fsSL https://raw.githubusercontent.com/lsst/qserv-operator/master/deploy.sh | bash
-    kubectl apply -k https://github.com/lsst/qserv-operator/base
+    git clone https://github.com/lsst/qserv-operator
+    cd qserv-operator
+    ./deploy.sh
+    kubectl apply -k manifests/base
+
 
 Run Qserv integration tests
 ===========================

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
-GIT_HASH="$(git describe --dirty --always)"
-TAG=${OP_VERSION:-${GIT_HASH}}
+RELEASE=0.0.1
+GIT_HASH="$(git rev-parse --short HEAD)"
+VERSION="$RELEASE-${GIT_HASH}"
 
-
-# Image version create by build procedure
-OP_IMAGE="qserv/qserv-operator:$TAG"
+# Image version created by build procedure
+OP_IMAGE="qserv/qserv-operator:$VERSION"

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,7 @@ k8s.io/apiextensions-apiserver v0.18.6 h1:vDlk7cyFsDyfwn2rNAO2DbmUbvXy5yT5GE3rrq
 k8s.io/apiextensions-apiserver v0.18.6/go.mod h1:lv89S7fUysXjLZO7ke783xOwVTm6lKizADfvUM/SS/M=
 k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
 k8s.io/apimachinery v0.18.6/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
+k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/apiserver v0.18.6/go.mod h1:Zt2XvTHuaZjBz6EFYzpp+X4hTmgWGy8AthNVnTdm3Wg=
 k8s.io/client-go v0.18.6 h1:I+oWqJbibLSGsZj8Xs8F0aWVXJVIoUHWaaJV3kUN/Zw=
 k8s.io/client-go v0.18.6/go.mod h1:/fwtGLjYMS1MaM5oi+eXhKwG+1UHidUEXRh6cNsdO0Q=

--- a/install-operator-sdk.sh
+++ b/install-operator-sdk.sh
@@ -7,8 +7,8 @@ set -x
 
 RELEASE_VERSION=v1.0.0
 
-# PGP_SERVER="keyserver.ubuntu.com"
-PGP_SERVER="pool.sks-keyservers.net"
+PGP_SERVER="keyserver.ubuntu.com"
+#PGP_SERVER="pool.sks-keyservers.net"
 
 curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu.asc

--- a/manifests/base/image.yaml
+++ b/manifests/base/image.yaml
@@ -1,0 +1,13 @@
+apiVersion: qserv.lsst.org/v1alpha1
+kind: Qserv
+metadata:
+  name: qserv
+spec:
+  czar:
+    image: qserv/qserv:a4f428a
+  worker:
+    image: qserv/qserv:a4f428a
+  replication:
+      image: qserv/qserv:a4f428a
+  xrootd:
+    image: qserv/qserv:a4f428a

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,6 +5,9 @@ commonLabels:
 resources:
 - qserv.yaml
 
+patchesStrategicMerge:
+- image.yaml
+
 secretGenerator:
 - name: secret-ingest-db-qserv
   files:

--- a/manifests/base/qserv.yaml
+++ b/manifests/base/qserv.yaml
@@ -8,15 +8,11 @@ spec:
   storagecapacity: "1Gi"
   networkpolicies: true
   czar:
-    image: "qserv/qserv:deps_20200729_0234"
   ingest:
     dbimage: "mariadb:10.2.16"
   worker:
     replicas: 2
-    image: "qserv/qserv:deps_20200729_0234"
   replication:
-      image: "qserv/qserv:tickets_DM-26034"
       dbimage: "mariadb:10.2.16"
   xrootd:
-    image: "qserv/qserv:deps_20200729_0234"
     replicas: 2

--- a/manifests/k3s/kustomization.yaml
+++ b/manifests/k3s/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../base
+patchesStrategicMerge:
+- qserv.yaml

--- a/manifests/k3s/qserv.yaml
+++ b/manifests/k3s/qserv.yaml
@@ -1,0 +1,10 @@
+apiVersion: qserv.lsst.org/v1alpha1
+kind: Qserv
+metadata:
+  name: qserv
+spec:
+  storageclass: "local-path"
+  worker:
+    replicas: 1
+  xrootd:
+    replicas: 1

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,6 +11,8 @@ const (
 
 	CorePathVolumeName = "corepath"
 
+	DataVolumeClaimTemplateName = QservName + "-data"
+
 	MariadbPort     = 3306
 	MariadbPortName = string(MariadbName)
 
@@ -34,7 +36,10 @@ const (
 	GraceTime = 30
 )
 
+// QservGID qserv user gid
 var QservGID int64 = 1000
+
+// QservUID qserv user uid
 var QservUID int64 = 1000
 
 // ContainerName name all containers
@@ -45,14 +50,22 @@ const (
 	CmsdName ContainerName = "cmsd"
 	// IngestDbName name for ingest database container
 	IngestDbName ContainerName = "ingest-db"
-	InitDbName   ContainerName = "initdb"
-	MariadbName  ContainerName = "mariadb"
-	ProxyName    ContainerName = "proxy"
-	ReplCtlName  ContainerName = "repl-ctl"
-	ReplDbName   ContainerName = "repl-db"
-	XrootdName   ContainerName = "xrootd"
-	WmgrName     ContainerName = "wmgr"
-	ReplWrkName  ContainerName = "repl-wrk"
+	// InitDbName name for database initialization containers
+	InitDbName ContainerName = "initdb"
+	// MariadbName name for mariadb container
+	MariadbName ContainerName = "mariadb"
+	// ProxyName name for proxy container
+	ProxyName ContainerName = "proxy"
+	// ReplCtlName name for replication controller container
+	ReplCtlName ContainerName = "repl-ctl"
+	// ReplDbName name for replication database container
+	ReplDbName ContainerName = "repl-db"
+	// XrootdName name for xrootd container
+	XrootdName ContainerName = "xrootd"
+	// WmgrName name for worker manager container
+	WmgrName ContainerName = "wmgr"
+	// ReplWrkName name for replication worker container
+	ReplWrkName ContainerName = "repl-wrk"
 )
 
 // PodClass name all classes of pod

--- a/pkg/resources/container.go
+++ b/pkg/resources/container.go
@@ -304,11 +304,6 @@ func getWmgrContainer(cr *qservv1alpha1.Qserv) (v1.Container, VolumeSet) {
 
 func getXrootdContainers(cr *qservv1alpha1.Qserv, component constants.PodClass) ([]v1.Container, VolumeSet) {
 
-	const (
-		CMSD = iota
-		XROOTD
-	)
-
 	spec := cr.Spec
 
 	volumeMounts := getXrootdVolumeMounts(component)
@@ -379,16 +374,8 @@ func getXrootdContainers(cr *qservv1alpha1.Qserv, component constants.PodClass) 
 	return containers, volumes.volumeSet
 }
 
-type NetworkAction string
-
-const (
-	httpAction NetworkAction = "http"
-	tcpAction  NetworkAction = "tcp"
-)
-
 func getHTTPProbe(portName string, periodSeconds int32, timeoutSeconds int32, path string) *v1.Probe {
-	var handler *v1.Handler
-	handler = &v1.Handler{
+	handler := &v1.Handler{
 		HTTPGet: &v1.HTTPGetAction{
 			Path: path,
 			Port: intstr.FromString(portName),
@@ -403,8 +390,7 @@ func getHTTPProbe(portName string, periodSeconds int32, timeoutSeconds int32, pa
 }
 
 func getTCPProbe(portName string, periodSeconds int32) *v1.Probe {
-	var handler *v1.Handler
-	handler = &v1.Handler{
+	handler := &v1.Handler{
 		TCPSocket: &v1.TCPSocketAction{
 			Port: intstr.FromString(portName),
 		},

--- a/pkg/resources/network.go
+++ b/pkg/resources/network.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// GenerateDefaultNetworkPolicy generate a NetworkPolicy
+// which prevents all incoming network connection to all pods in namespace
 func GenerateDefaultNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
 	return &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -25,6 +27,7 @@ func GenerateDefaultNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]str
 	}
 }
 
+// GenerateCzarNetworkPolicy generate a NetworkPolicy for czar pod
 func GenerateCzarNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
 	return &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -73,6 +76,7 @@ func GenerateCzarNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string
 	}
 }
 
+// GenerateReplDBNetworkPolicy generate a NetworkPolicy for replication database pod
 func GenerateReplDBNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
 	return &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -111,6 +115,7 @@ func GenerateReplDBNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]stri
 	}
 }
 
+// GenerateWorkerNetworkPolicy generate a NetworkPolicy for worker pods
 func GenerateWorkerNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
 	return &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -169,6 +174,7 @@ func GenerateWorkerNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]stri
 	}
 }
 
+// GenerateXrootdRedirectorNetworkPolicy generate a NetworkPolicy for xrootd redirector pods
 func GenerateXrootdRedirectorNetworkPolicy(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.NetworkPolicy {
 	return &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/service.go
+++ b/pkg/resources/service.go
@@ -184,6 +184,7 @@ func GenerateWorkerService(cr *qservv1alpha1.Qserv, labels map[string]string) *v
 	}
 }
 
+// GenerateXrootdRedirectorService generates headless service for xrootd redirectors StatefulSet
 func GenerateXrootdRedirectorService(cr *qservv1alpha1.Qserv, labels map[string]string) *v1.Service {
 	name := util.GetName(cr, string(constants.XrootdRedirector))
 	namespace := cr.Namespace

--- a/pkg/resources/statefulset.go
+++ b/pkg/resources/statefulset.go
@@ -1,15 +1,14 @@
 package qserv
 
 import (
+	qservv1alpha1 "github.com/lsst/qserv-operator/api/v1alpha1"
+	"github.com/lsst/qserv-operator/pkg/constants"
+	"github.com/lsst/qserv-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	qservv1alpha1 "github.com/lsst/qserv-operator/api/v1alpha1"
-	"github.com/lsst/qserv-operator/pkg/constants"
-	"github.com/lsst/qserv-operator/pkg/util"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var log = logf.Log.WithName("qserv")
@@ -66,7 +65,7 @@ func GenerateCzarStatefulSet(cr *qservv1alpha1.Qserv, labels map[string]string) 
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: GetDataVolumeClaimTemplateName(),
+						Name: constants.DataVolumeClaimTemplateName,
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
 						AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
@@ -136,7 +135,7 @@ func GenerateIngestDbStatefulSet(cr *qservv1alpha1.Qserv, labels map[string]stri
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: GetDataVolumeClaimTemplateName(),
+						Name: constants.DataVolumeClaimTemplateName,
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
 						AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
@@ -255,7 +254,7 @@ func GenerateReplicationDbStatefulSet(cr *qservv1alpha1.Qserv, labels map[string
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: GetDataVolumeClaimTemplateName(),
+						Name: constants.DataVolumeClaimTemplateName,
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
 						AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
@@ -276,20 +275,10 @@ func GenerateReplicationDbStatefulSet(cr *qservv1alpha1.Qserv, labels map[string
 	return ss
 }
 
-func GetDataVolumeClaimTemplateName() string {
-	return constants.QservName + "-data"
-}
-
+// GenerateWorkerStatefulSet generate statefulset specification for Qserv Workers
 func GenerateWorkerStatefulSet(cr *qservv1alpha1.Qserv, labels map[string]string) *appsv1.StatefulSet {
 	name := cr.Name + "-" + string(constants.Worker)
 	namespace := cr.Namespace
-
-	const (
-		MARIADB = iota
-		WMGR
-	)
-
-	const INIT = 0
 
 	labels = util.MergeLabels(labels, util.GetLabels(constants.Worker, cr.Name))
 
@@ -347,7 +336,7 @@ func GenerateWorkerStatefulSet(cr *qservv1alpha1.Qserv, labels map[string]string
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: GetDataVolumeClaimTemplateName(),
+						Name: constants.DataVolumeClaimTemplateName,
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
 						AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
@@ -367,6 +356,7 @@ func GenerateWorkerStatefulSet(cr *qservv1alpha1.Qserv, labels map[string]string
 	return ss
 }
 
+// GenerateXrootdStatefulSet generate statefulset specification for xrootd redirectors
 func GenerateXrootdStatefulSet(cr *qservv1alpha1.Qserv, labels map[string]string) *appsv1.StatefulSet {
 	namespace := cr.Namespace
 	name := util.GetName(cr, string(constants.XrootdRedirector))

--- a/pkg/resources/volume.go
+++ b/pkg/resources/volume.go
@@ -33,12 +33,6 @@ func (ivs *InstanceVolumeSet) make(cr *qservv1alpha1.Qserv) {
 	ivs.cr = cr
 }
 
-func (vs *VolumeSet) add(vols VolumeSet) {
-	for k, v := range vols {
-		(*vs)[k] = v
-	}
-}
-
 func (ivs *InstanceVolumeSet) addConfigMapExecVolume(container constants.ContainerName, executeMode *int32) {
 
 	suffix := fmt.Sprintf("%s-start", container)
@@ -98,7 +92,7 @@ func (ivs *InstanceVolumeSet) addEmptyDirVolume(name string) {
 
 func (ivs *InstanceVolumeSet) addDataVolume(cr *qservv1alpha1.Qserv) {
 	name := "data"
-	claimName := fmt.Sprintf("%s-%s-%s-0", GetDataVolumeClaimTemplateName(), cr.Name, constants.Czar)
+	claimName := fmt.Sprintf("%s-%s-%s-0", constants.DataVolumeClaimTemplateName, cr.Name, constants.Czar)
 	volume := v1.Volume{
 		Name: name,
 		VolumeSource: v1.VolumeSource{
@@ -161,7 +155,7 @@ func getCorePathVolumeMount(mountPath string) v1.VolumeMount {
 func getDataVolumeMount() v1.VolumeMount {
 	return v1.VolumeMount{
 		MountPath: filepath.Join("/", "qserv", "data"),
-		Name:      GetDataVolumeClaimTemplateName(),
+		Name:      constants.DataVolumeClaimTemplateName,
 		ReadOnly:  false,
 	}
 }

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var log = logf.Log.WithName("syncer")

--- a/pkg/syncers/configmap.go
+++ b/pkg/syncers/configmap.go
@@ -30,8 +30,9 @@ func NewDotQservConfigMapSyncer(r *qservv1alpha1.Qserv, c client.Client, scheme 
 	})
 }
 
-func NewSqlConfigMapSyncer(r *qservv1alpha1.Qserv, c client.Client, scheme *runtime.Scheme, db constants.PodClass) syncer.Interface {
-	cm := qserv.GenerateSqlConfigMap(r, controllerLabels, db)
+// NewSQLConfigMapSyncer generate configmap specification for initContainer in charge of database initialization
+func NewSQLConfigMapSyncer(r *qservv1alpha1.Qserv, c client.Client, scheme *runtime.Scheme, db constants.PodClass) syncer.Interface {
+	cm := qserv.GenerateSQLConfigMap(r, controllerLabels, db)
 	objectName := fmt.Sprintf("%sSqlConfigMap", strings.Title(string(db)))
 	return syncer.NewObjectSyncer(objectName, r, cm, c, scheme, func() error {
 		return nil

--- a/pkg/syncers/network.go
+++ b/pkg/syncers/network.go
@@ -10,14 +10,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// NewNetworkPoliciesSyncer generate NetworkPolicies specifications all Qserv pods
 func NewNetworkPoliciesSyncer(r *qservv1alpha1.Qserv, c client.Client, scheme *runtime.Scheme) []syncer.Interface {
 
-	tmp_labels := map[string]string{
+	tmpLabels := map[string]string{
 		"app":      constants.AppLabel,
 		"instance": r.Name,
 	}
 
-	labels := util.MergeLabels(controllerLabels, tmp_labels)
+	labels := util.MergeLabels(controllerLabels, tmpLabels)
 	return []syncer.Interface{
 		syncer.NewObjectSyncer("DefaultNetworkPolicy", r, qserv.GenerateDefaultNetworkPolicy(r, labels), c, scheme, noFunc),
 		syncer.NewObjectSyncer("CzarNetworkPolicy", r, qserv.GenerateCzarNetworkPolicy(r, labels), c, scheme, noFunc),

--- a/pkg/util/funcs.go
+++ b/pkg/util/funcs.go
@@ -2,10 +2,12 @@ package util
 
 import "text/template"
 
+// TemplateFunctions contain functions used in templates for Qserv configuration files
 var TemplateFunctions = template.FuncMap{
 	"Iterate": IterateCount,
 }
 
+// IterateCount return a list of integer in the  for [0, 1, ..., n]
 func IterateCount(count uint) []int {
 	items := make([]int, count)
 	for i := uint(0); i < count; i++ {

--- a/pkg/util/label.go
+++ b/pkg/util/label.go
@@ -9,37 +9,36 @@ func MergeLabels(allLabels ...map[string]string) map[string]string {
 	res := map[string]string{}
 
 	for _, labels := range allLabels {
-		if labels != nil {
-			for k, v := range labels {
-				res[k] = v
-			}
+		for k, v := range labels {
+			res[k] = v
 		}
 	}
 	return res
 }
 
 // GetLabels returns the labels for the component with specific role
-func GetLabels(component constants.PodClass, cr_name string) map[string]string {
-	return generatePodLabels(component, cr_name)
+func GetLabels(component constants.PodClass, crName string) map[string]string {
+	return generatePodLabels(component, crName)
 }
 
-func generatePodLabels(component constants.PodClass, cr_name string) map[string]string {
+func generatePodLabels(component constants.PodClass, crName string) map[string]string {
 	componentStr := string(component)
 	return map[string]string{
 		"app":       constants.AppLabel,
 		"component": componentStr,
-		"instance":  cr_name,
+		"instance":  crName,
 	}
 }
 
-func GetContainerLabels(container constants.ContainerName, cr_name string) map[string]string {
-	return generateContainerLabels(container, cr_name)
+// GetContainerLabels returns the labels for containers
+func GetContainerLabels(container constants.ContainerName, crName string) map[string]string {
+	return generateContainerLabels(container, crName)
 }
 
-func generateContainerLabels(container constants.ContainerName, cr_name string) map[string]string {
+func generateContainerLabels(container constants.ContainerName, crName string) map[string]string {
 	return map[string]string{
 		"app":       constants.AppLabel,
 		"container": string(container),
-		"instance":  cr_name,
+		"instance":  crName,
 	}
 }

--- a/pkg/util/name.go
+++ b/pkg/util/name.go
@@ -7,7 +7,7 @@ import (
 
 	qservv1alpha1 "github.com/lsst/qserv-operator/api/v1alpha1"
 	"github.com/lsst/qserv-operator/pkg/constants"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var log = logf.Log.WithName("name")
@@ -75,7 +75,7 @@ func PrefixConfigmap(r *qservv1alpha1.Qserv, name string) string {
 	return fmt.Sprintf("%s-%s", r.Name, name)
 }
 
-// PrefixConfigMap add a common prefix to all ConfigMap names of a given Qserv instance
+// GetConfigVolumeName add a common prefix to all pod volume names attaching a configmap
 func GetConfigVolumeName(suffix string) string {
 	return fmt.Sprintf("config-%s", suffix)
 }

--- a/tests/tools/wait-qserv-ready.sh
+++ b/tests/tools/wait-qserv-ready.sh
@@ -52,6 +52,9 @@ do
   kubectl get pod -l "app=qserv,instance=$INSTANCE"
   if [ "$VERBOSE" = true ]; then
     kubectl describe pod -l "app=qserv,instance=$INSTANCE"
+    df -h
+    kubectl get pvc
+    kubectl get pv
   fi
 done
 


### PR DESCRIPTION
- Generate manifests
- Add minimal unit test support
- Refactor e2e tests
- Refactor kustomize templates
- Add documentation
- Add example aliases
- Change imagePullPolicy for operator
- Improve kind support: load image after build
- Merge manually branch tickets/DM-26293
- Add local storage management
- Move local storage management scripts to examples
- Add redundancy for pgp keyserver
- Add standalone deployment script
- Update documentation
- Add github action for CI
- Update qserv image
- Manage qserv image with kustomize
- Upgrade to latest qserv image

Improve CI
- Scan container image
- Perform static code analysis