### PR TITLE
Update in2p3-dev config with new requirements

### DIFF
--- a/manifests/in2p3-dev/qserv.yaml
+++ b/manifests/in2p3-dev/qserv.yaml
@@ -5,16 +5,15 @@ metadata:
 spec:
   queryService:
     type: NodePort
-    nodePort: 30040
+    nodePort: 30041
   storageClassName: "qserv-local-storage"
   storage: "100Gi"
   # replication:
   #    image: "qserv/replica:tools-w.2018.16-1345-gb9191ae-dirty"
   worker:
-    replicas: 20 
+    replicas: 15 
   tolerations:
   - key: "dedicated"
     operator: "Equal"
     value: "qserv"
     effect: "NoSchedule"
-


### PR DESCRIPTION
Hello,
As discussed with @fjammes, this update reduces the number of nodes in the `in2p3-dev` configuration, similarly to what was done in commit c7c4f7bf4a76eb136f9b8a0f19e6f29d456fabe6 with `in2p3`
It also uses another port for exposing the service, so it can cohabit with the production service on the same cluster.