### PR TITLE
The Replication Controller is forced to make chunk disposition changes

### DIFF
--- a/configmap/repl-ctl/start/start.sh
+++ b/configmap/repl-ctl/start/start.sh
@@ -27,5 +27,6 @@ entrypoint --log-level DEBUG replication-controller \
     --registry-port="{{.HTTPPort}}" \
     --replication-interval=1200 \
     --worker-evict-timeout=3600 \
-    --xrootd-host="{{.XrootdRedirectorDN}}"
+    --xrootd-host="{{.XrootdRedirectorDN}}" \
+    --qserv-sync-force
 


### PR DESCRIPTION
A lack of this option in the previous version of the operator may result
in the delayed chunk disposition updates at workers. Under certain conditions,
such as Qserv beig heavily loaded by the shared scan queries, this might cause
failures in the query processing, or incorrect functioning of the Controller.
The chuk disposition updates are tipically triggered by the Replication Controller's
algorithms (increasing/decreasing the replication levels of chunks, rebalancing
or fixing up replicas), or by new catalogs/tables ingested into Qserv.