### PR TITLE
Increased key limits in the configurations of the MariaDB services

### DIFF
--- a/configmap/ingest-db/etc/my.cnf
+++ b/configmap/ingest-db/etc/my.cnf
@@ -15,10 +15,16 @@ host_cache_size=0
 
 # Configure max number of connections
 # Recommended value: 256 for every 50 simultaneous queries
-max_connections = 4096
+max_connections = 16384
+connect_timeout = 28800
 
 socket = /qserv/data/mysql/mysql.sock
 port = 3306
+
+# Extend read and write connection timeouts that can be triggered
+# by large result sets.
+net_read_timeout=90000
+net_write_timeout=90000
 
 query-cache-size = 0
 

--- a/configmap/repl-db/etc/my.cnf
+++ b/configmap/repl-db/etc/my.cnf
@@ -15,10 +15,16 @@ host_cache_size=0
 
 # Configure max number of connections
 # Recommended value: 256 for every 50 simultaneous queries
-max_connections = 4096
+max_connections = 16384
+connect_timeout = 28800
 
 socket = /qserv/data/mysql/mysql.sock
 port = 3306
+
+# Extend read and write connection timeouts that can be triggered
+# by large result sets.
+net_read_timeout=90000
+net_write_timeout=90000
 
 query-cache-size = 0
 


### PR DESCRIPTION
The previous limits were too low for production instances