### PR TITLE
DM-37120: Add utility node affinity for redirector and ingest db pods at IDF

### DIFF
--- a/manifests/gke-qserv-int/qserv.yaml
+++ b/manifests/gke-qserv-int/qserv.yaml
@@ -14,3 +14,24 @@ spec:
   worker:
     storage: "10Ti"
     replicas: 5
+  ingest:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - 'utility'
+  xrootd:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - 'utility'
+

--- a/manifests/gke-qserv-prod/qserv.yaml
+++ b/manifests/gke-qserv-prod/qserv.yaml
@@ -14,3 +14,24 @@ spec:
   worker:
     storage: "10Ti"
     replicas: 5
+  ingest:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - 'utility'
+  xrootd:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - 'utility'
+

--- a/manifests/gke-qserv-prod/qserv.yaml
+++ b/manifests/gke-qserv-prod/qserv.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   storage: "100Gi"
   czar:
-    storage: "2Ti"
+    storage: "4Ti"
   queryService:
       loadBalancerIP: 10.140.1.211
       annotations:


### PR DESCRIPTION
Elaborate the IDF operator yamls to set utility node affinity for the xrootd redirector and ingest db pods, which otherwise were sometimes being scheduled on worker nodes.

Also update storage configuration for czar on IDF -prod to 4Ti, to match the configuration we are using for IDF -int.