### PR TITLE
2024.5.1 rc1

### DIFF
--- a/.github/workflows/itest-full.yml
+++ b/.github/workflows/itest-full.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        results_protocol: [results_protocol_xroot, results_protocol_ssi, results_protocol_http]
+        results_protocol: [results_protocol_xroot, results_protocol_http]
     uses: ./.github/workflows/itest.yml
     needs: build
     with:

--- a/configmap/cmsd-server/start/start.sh
+++ b/configmap/cmsd-server/start/start.sh
@@ -12,4 +12,7 @@ entrypoint --log-level DEBUG worker-cmsd \
           --vnid-config "@/usr/local/lib64/libreplica.so {{.WorkerDatabaseLocalURL}} 0 0" \
           --cmsd-manager-name {{.XrootdRedirectorDN}} \
           --cmsd-manager-count {{.XrootdRedirectorReplicas}} \
-          --log-cfg-file "/cm-etc/log.cnf"
+          --log-cfg-file "/cm-etc/log.cnf" \
+          --instance-id="{{.QservInstance}}" \
+          --registry-host="{{.ReplicationRegistryDN}}" \
+          --registry-port="{{.HTTPPort}}"

--- a/configmap/proxy/start/start.sh
+++ b/configmap/proxy/start/start.sh
@@ -23,4 +23,7 @@ entrypoint --log-level DEBUG proxy \
   --db-uri "mysql://qsmaster@127.0.0.1:3306?socket={{.MariadbSocket}}" \
   --db-admin-uri "mysql://root:$PASSWORD@127.0.0.1:3306?socket={{.MariadbSocket}}" \
   --xrootd-manager qserv-xrootd-redirector \
-  --log-cfg-file /cm-etc/log.cnf
+  --log-cfg-file /cm-etc/log.cnf \
+  --instance-id="{{.QservInstance}}" \
+  --registry-host="{{.ReplicationRegistryDN}}" \
+  --registry-port="{{.HTTPPort}}"

--- a/configmap/xrootd-server/start/start.sh
+++ b/configmap/xrootd-server/start/start.sh
@@ -21,4 +21,7 @@ entrypoint --log-level DEBUG worker-xrootd \
           --cmsd-manager-count "{{.XrootdRedirectorReplicas}}" \
           --mysql-monitor-password "CHANGEME_MONITOR" \
           --log-cfg-file "/cm-etc/log.cnf" \
-          --results-protocol "{{.ResultsProtocol}}"'
+          --results-protocol "{{.ResultsProtocol}}" \
+          --instance-id="{{.QservInstance}}" \
+          --registry-host="{{.ReplicationRegistryDN}}" \
+          --registry-port="{{.HTTPPort}}"'

--- a/manifests/operator-ns-scoped.yaml
+++ b/manifests/operator-ns-scoped.yaml
@@ -3775,7 +3775,7 @@ spec:
                         type: object
                     type: object
                   resultsProtocol:
-                    default: SSI
+                    default: HTTP
                     description: ResultsProtocol defines the protocol used to retrieve
                       results from workers
                     type: string

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -3775,7 +3775,7 @@ spec:
                         type: object
                     type: object
                   resultsProtocol:
-                    default: SSI
+                    default: HTTP
                     description: ResultsProtocol defines the protocol used to retrieve
                       results from workers
                     type: string

--- a/manifests/results_protocol_ssi/kustomization.yaml
+++ b/manifests/results_protocol_ssi/kustomization.yaml
@@ -1,5 +1,0 @@
-bases:
-- ../base
-patchesStrategicMerge:
-- qserv.yaml
-

--- a/manifests/results_protocol_ssi/qserv.yaml
+++ b/manifests/results_protocol_ssi/qserv.yaml
@@ -1,7 +1,0 @@
-apiVersion: qserv.lsst.org/v1beta1
-kind: Qserv
-metadata:
-  name: qserv
-spec:
-  worker:
-    resultsProtocol: SSI

--- a/manifests/usdf-qserv/kustomization.yaml
+++ b/manifests/usdf-qserv/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../base
+patchesStrategicMerge:
+- qserv.yaml

--- a/manifests/usdf-qserv/qserv.yaml
+++ b/manifests/usdf-qserv/qserv.yaml
@@ -1,0 +1,90 @@
+apiVersion: qserv.lsst.org/v1beta1
+kind: Qserv
+metadata:
+  name: qserv
+spec:
+  storageClassName: "rubin-qserv-storage"
+  storage: "1Ti"
+  tolerations:
+    - effect: NoSchedule
+      key: key
+      operator: Equal
+      value: qserv
+  queryService:
+      annotations:
+          metallb.universe.tf/address-pool: sdf-services
+          type: LoadBalancer
+          loadBalancerIP: 10.107.187.124
+  czar:
+    storageClassName: "rubin-qserv-storage"
+    storage: "3Ti"
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - czar
+    proxyResources:
+      requests:
+        cpu: 32
+  worker:
+    storage: "10Ti"
+    replicas: 28
+    affinity:
+      podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "component"
+                    operator: In
+                    values:
+                    - worker
+                  - key: "app"
+                    operator: In
+                    values:
+                    - qserv
+              topologyKey: "kubernetes.io/hostname"
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - worker
+    replicationResources:
+      limits:
+        cpu: 16
+  ingest:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - 'utility'
+  replication:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - czar
+  xrootd:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+              - 'utility'


### PR DESCRIPTION
- Added support for deploying Qserv at USDF.
- Eliminated XROOTD/SSI protocol option.
- Switched to the HTTP-based protocol for delivering worker results to Czar(s)